### PR TITLE
Feel cache and don't empty it.

### DIFF
--- a/facetwp-wp-cli.php
+++ b/facetwp-wp-cli.php
@@ -53,8 +53,6 @@ class CLI extends WP_CLI_Command {
 			WP_CLI::error( 'FacetWP plugin is not activated.' );
 		}
 
-		wp_suspend_cache_addition( true );
-
 		$post_type = 'any';
 		if ( ! empty( $assoc_args['post-type'] ) ) {
 			$post_type = $assoc_args['post-type'];
@@ -118,7 +116,6 @@ class CLI extends WP_CLI_Command {
 		global $wpdb, $wp_object_cache, $wp_actions;
 		$wpdb->queries = array(); 
 		$wp_actions = array();
-		wp_cache_flush();
 		if ( !is_object( $wp_object_cache ) ){
 			return;
 		}


### PR DESCRIPTION
Because of the insane amount of terms some installations have, we need the cache to stay active, even if this leads to memory issues for now.